### PR TITLE
Use event listener to automatically update the theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 > Support dark mode in your Svelte apps.
 
+<!-- REPO_URL -->
+
 This component sets the theme based on the user’s preferred color scheme using [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia).
 
 The preferred theme is persisted using the [window.localStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
-
-<!-- REPO_URL -->
 
 ---
 
@@ -26,7 +26,7 @@ npm i -D svelte-dark-mode
 
 ### Basic
 
-The initial `theme` is set to either `"dark"` or `"light"` based on the user’s system preference.
+The `theme` is set to either `"dark"` or `"light"` based on the user’s system preference.
 
 ```svelte
 <script>
@@ -38,6 +38,15 @@ The initial `theme` is set to either `"dark"` or `"light"` based on the user’s
   $: document.body.className = theme; // "dark" or "light"
 </script>
 
+<DarkMode bind:theme />
+
+<h1>This is {theme} mode.</h1>
+<p>Change the theme and reload the page.</p>
+
+<button on:click={() => (theme = switchTheme)}>
+  Switch to {switchTheme} mode
+</button>
+
 <style>
   :global(.dark) {
     background: #032f62;
@@ -45,19 +54,11 @@ The initial `theme` is set to either `"dark"` or `"light"` based on the user’s
   }
 </style>
 
-<DarkMode bind:theme />
-
-<h1>This is {theme} mode.</h1>
-<p>Change the theme and reload the page.</p>
-
-<button type="button" on:click={() => (theme = switchTheme)}>
-  Switch to {switchTheme} mode
-</button>
 ```
 
 ### Server-side rendering (SSR)
 
-If you use server-side rendering (SSR), employ the `afterUpdate` lifecycle when accessing `document.body` or `document.documentElement`.
+When using server-side rendering (SSR), employ the `afterUpdate` lifecycle to access `document.body` or `document.documentElement`.
 
 ```html
 <script>
@@ -71,7 +72,7 @@ If you use server-side rendering (SSR), employ the `afterUpdate` lifecycle when 
 
 ### System preference change
 
-If the user changes their color scheme preference at the system level, the theme will be updated when the page is reloaded.
+The theme will automatically be updated if the user changes their color scheme preference at the system level.
 
 ### Custom `localStorage` key
 
@@ -89,10 +90,10 @@ localStorage.getItem("custom-theme-key"); // "dark" || "light"
 
 ### Props
 
-| Prop name | Value                                   |
-| :-------- | :-------------------------------------- |
-| theme     | `"dark"` or `"light"` (default: `null`) |
-| key       | `string` (default: `"theme"`)           |
+| Prop name | Value                                     |
+| :-------- | :---------------------------------------- |
+| theme     | `"dark"` or `"light"` (default: `"dark"`) |
+| key       | `string` (default: `"theme"`)             |
 
 ### Dispatched events
 
@@ -111,11 +112,11 @@ localStorage.getItem("custom-theme-key"); // "dark" || "light"
   bind:theme
   on:change={(e) => {
     events = [...events, e.detail];
-    console.log(e.detail); // "dark" | "light"
   }}
 />
 
-{events.join(', ')}
+{events.join(", ")}
+
 ```
 
 ## TypeScript

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "predeploy": "rollup -c",
     "deploy": "npx gh-pages -d dist",
     "prepack": "BUNDLE=true rollup -c",
-    "svelte-check": "svelte-check"
+    "test": "svelte-check"
   },
   "devDependencies": {
-    "svelte": "^3.32.1",
-    "svelte-check": "^1.1.31",
+    "svelte": "^3.35.0",
+    "svelte-check": "^1.2.3",
     "svelte-readme": "^3.0.0"
   },
   "repository": {

--- a/types/DarkMode.d.ts
+++ b/types/DarkMode.d.ts
@@ -1,15 +1,17 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export type Theme = null | "dark" | "light";
+export type Theme = "dark" | "light";
 
 export interface DarkModeProps {
   /**
-   * @default null
+   * The current theme
+   * @default "dark"
    */
   theme?: Theme;
 
   /**
+   * Customize the local storage key that stores the current theme
    * @default "theme"
    */
   key?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -715,10 +715,10 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svelte-check@^1.1.31:
-  version "1.1.31"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-1.1.31.tgz#8cc0945b678aa6848c3991827e10d168b6b6b8ab"
-  integrity sha512-FUi32gqR7g/9XjRB0qmldxqxm/ksLLQULM7P0tSwX21rOpV43UypZ7ThblaMCPpVnKrB+UqA4JRqEGNHUakLdg==
+svelte-check@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-1.2.3.tgz#bf39879f8cecd380a8f75553d169335cc9395497"
+  integrity sha512-EAuxtwjpTL2K7MHCDKUtt8YeDhM8sf8ZHTdODfE7yYb53nDD8u+p5I5Ub77VPSqgHUlaJh66ieB14rrLeA9YxA==
   dependencies:
     chalk "^4.0.0"
     chokidar "^3.4.1"
@@ -759,10 +759,10 @@ svelte-readme@^3.0.0:
     rollup-plugin-svelte "^7.0.0"
     rollup-plugin-terser "^7.0.2"
 
-svelte@^3.32.1:
-  version "3.32.1"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.32.1.tgz#c4b6e35517d0ed77e652cc8964ef660afa2f70f3"
-  integrity sha512-j1KmD2ZOU0RGq1/STDXjwfh0/eJ/Deh2NXyuz1bpR9eOcz9yImn4CGxXdbSAN7cMTm9a7IyPUIbuBCzu/pXK0g==
+svelte@^3.35.0:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.35.0.tgz#e0d0ba60c4852181c2b4fd851194be6fda493e65"
+  integrity sha512-gknlZkR2sXheu/X+B7dDImwANVvK1R0QGQLd8CNIfxxGPeXBmePnxfzb6fWwTQRsYQG7lYkZXvpXJvxvpsoB7g==
 
 terser@^5.0.0:
   version "5.5.0"


### PR DESCRIPTION
**Breaking Changes**

- `theme` type changed to `"dark" | "light"`

**Features**

- validate the `theme` value at runtime (must be either "dark" or "light")
- add event listener to automatically update the theme

