### PR TITLE
refactor(types): use import type, remove inferred annotations

### DIFF
--- a/src/DarkMode.svelte
+++ b/src/DarkMode.svelte
@@ -13,7 +13,6 @@
   /**
    * Specify a custom local storage key
    * to store the current theme.
-   * @type {string}
    */
   export let key = "theme";
 

--- a/src/DarkMode.svelte
+++ b/src/DarkMode.svelte
@@ -1,7 +1,6 @@
 <script>
   /**
    * @typedef {"dark" | "light"} Theme
-   * @event {Theme} change
    */
 
   /**

--- a/src/DarkMode.svelte.d.ts
+++ b/src/DarkMode.svelte.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export type Theme = "dark" | "light";
 


### PR DESCRIPTION
- use `import type` to import `SvelteComponentTyped` interface
- remove inferred JSDoc type for `key` prop
- remove invalid `@event` JSDoc type